### PR TITLE
Fix title displaying null

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaTitleTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/JavaTitleTranslator.java
@@ -65,6 +65,11 @@ public class JavaTitleTranslator extends PacketTranslator<ServerTitlePacket> {
                 break;
         }
 
+        // This will replace the 'null' message sometimes sent and replace it with a space so subtitle can still work
+        if ("null".equals(titlePacket.getText())) {
+            titlePacket.setText(" ");
+        }
+
         session.sendUpstreamPacket(titlePacket);
     }
 }


### PR DESCRIPTION
This will replace the 'null' message sometimes sent and replace it with a space so subtitle can still work.